### PR TITLE
fix: Do not rename `,`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,18 @@ CI_COMMIT_REF_NAME ?= master
 
 HOSTNAME = $(shell hostname)
 
+# When auto-adding everything of the repo, only do it for documents,
+# not for logic/config/documentation.
+GIT_ADD = $(shell git add . -- ':!okdoc' ':!config.yml' ':!README.org')
+
 # --- default target ---
 .PHONY: doit
 doit:
-	git add .
+	$(GIT_ADD)
 	make rename
 	git pull
 	make -j 6 textfiles
-	git add .
+	$(GIT_ADD)
 	./okdoc/sort.rb -ai
 
 .PHONY: install
@@ -81,7 +85,7 @@ sort:
 .PHONY: push
 push: $(GIT)
 	# add files
-	$(GIT) add .
+	$(GIT_ADD)
 	# re-write the log
 	echo "From $(HOSTNAME) at $(shell date -I)" > log.txt
 	$(GIT) status >> log.txt

--- a/rename.rb
+++ b/rename.rb
@@ -2,6 +2,6 @@
 # coding: utf-8
 
 Dir.glob('**/*.pdf').each do |file|
-  renamed = file.gsub(%r{[^A-Za-z0-9._\-\/äüöÄÜÖ]}, '_')
+  renamed = file.gsub(%r{[^A-Za-z0-9.,_\-\/äüöÄÜÖ]}, '_')
   puts 'mv "%s" "%s"' % [file, renamed] if renamed != file
 end

--- a/sort.rb
+++ b/sort.rb
@@ -14,6 +14,7 @@ OptionParser.new do |opts|
 
   opts.on('-a', '--act-immediately', 'Move files right away') { |d| options.doit = d }
   opts.on('-i', '--interactive', 'Run in interactive mode') { |i| options.interactive = i }
+  opts.on('-f', '--file FILE', 'Sort just one file') { |f| options.file = f; options.interactive = true }
   opts.on('-v', '--verbose', 'Run verbosely') { |v| options.verbose = v }
   opts.on('-y', '--yes', 'Auto approve') { |y| options.yes = y }
 end.parse!
@@ -41,7 +42,11 @@ config = load_config
 
 FILENAME_PATTERN = Regexp.new(config['filename_pattern']).freeze
 
-files = Dir.glob(config['file_glob'], File::FNM_CASEFOLD).sort
+if options.file
+  files = [options.file]
+else
+  files = Dir.glob(config['file_glob'], File::FNM_CASEFOLD).sort
+end
 
 actions = {}
 


### PR DESCRIPTION
Renaming `,` to `_` conflicts with the `tags` functionality. When setting multiple tags separated by commas, these files would get renamed when running `make rename`.

If you think that this is not a good practice as a default, then I propose to refactor the `renamed` regex into the config (similar to the `filename_pattern`).

#Based on #2.