### PR TITLE
Revert "feat: Do not randomly wait for window paint, but work with events"

### DIFF
--- a/i3_focus_other.sh
+++ b/i3_focus_other.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# ================================================================================== #
+# Focus the next window on the current workspace in i3, e.g. for binding to Alt+Tab  #
+# Depends: jq, awk, i3wm (obviously)                                                 #
+# Author: Nervengift <dev@nerven.gift>                                               #
+# License: Don't think this deserves a license, Public Domain                        #
+# Known bugs: doesn't work with non-window container focused                         #
+# ================================================================================== #
+
+ws=$(i3-msg -t get_workspaces|jq "map(select(.focused))[]|.name")
+windows=$(i3-msg -t get_tree|jq ".nodes|map(.nodes[])|map(.nodes[])|map(select(.type==\"workspace\" and .name==$ws))[0].nodes|map(recurse(.nodes[]))|map(.window)|.[]|values")
+current=$(i3-msg -t get_tree|jq "recurse(.nodes[])|select(.focused)|.window")
+if [ "x$current" != "xnull" ]; then
+	next=$(echo $windows | awk "BEGIN {RS=\" \";FS=\"   \"};NR == 1 {w=\$1};{if (f == 1){w=\$1;f=0}else if (\$1 == \"$current\") f=1};END {print w}")
+	i3-msg "[id=$next]" focus > /dev/null
+fi

--- a/sort.rb
+++ b/sort.rb
@@ -151,25 +151,10 @@ files.each_with_index do |pdf, index|
       final = data
     else
       if options.interactive
-
-        # Search for the window running make or sort.rb to be able to
-        # focus on it later
-        terminal_win_id = `wmctrl -l | awk '/sort.rb|make/ {print $1}'`.chomp
-
         # become interactive, show the document
-        pid = spawn("evince #{pdf}")
-
-        # Wait for the window to open and grab its window ID
-        winid=""
-        until !winid.empty?
-          winid=`wmctrl -lp | awk -vpid=#{pid} '$3==pid {print $1; exit}'`
-        end
-
-        # Ensure evince window is on the right
-        `i3-msg move right`
-
-        # Don't focus on the new evince window, but the input prompt of `sort`.
-        `wmctrl -ia "#{terminal_win_id}"`
+        pid = spawn("i3-msg exec 'evince #{File.expand_path(pdf)}'")
+        # Wait for evince to draw
+        spawn("i3-msg -t subscribe -m '[ \"window\" ]' | read")
 
         # show the calculated results
         yaml = YAML.dump(data)
@@ -178,6 +163,9 @@ files.each_with_index do |pdf, index|
         puts "# [#{index}/#{files.count}] #{pdf}"
         puts yaml
         puts
+
+        # Don't focus on the new evince window, but the input prompt of `sort.
+        `./okdoc/i3_focus_other.sh`
 
         # ask what to do
         action = cli.ask('(A)ccept/(r)etry/(d)elete/(t)ag/e(x)it? ') do |q|

--- a/sort.rb
+++ b/sort.rb
@@ -152,9 +152,7 @@ files.each_with_index do |pdf, index|
     else
       if options.interactive
         # become interactive, show the document
-        pid = spawn("i3-msg exec 'evince #{File.expand_path(pdf)}'")
-        # Wait for evince to draw
-        spawn("i3-msg -t subscribe -m '[ \"window\" ]' | read")
+        pid = spawn("evince #{pdf}")
 
         # show the calculated results
         yaml = YAML.dump(data)
@@ -164,6 +162,7 @@ files.each_with_index do |pdf, index|
         puts yaml
         puts
 
+        sleep 0.25 # That's just enough time for evince to show.
         # Don't focus on the new evince window, but the input prompt of `sort.
         `./okdoc/i3_focus_other.sh`
 


### PR DESCRIPTION
Rubys `fork` returns the PID for `sh`, not for evince.

I have tried to do a workaround using the shell, but Ruby waits for the shell to exit - even when using `disown` or `nohup`.

![image](https://user-images.githubusercontent.com/505721/107929574-20af8880-6f7a-11eb-9115-005de4ae7e30.png)


So, waiting is the fashizzle.

Yak shaving on our own tooling is not. I've spent too much time on okdoc and hereby pledge to not make any more changes to it.

 So, let's wait.

