### PR TITLE
fix: Remove `build` dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ build: Dockerfile
 	docker build -t okocr .
 
 .PHONY: textfiles-docker
-textfiles-docker: build
+textfiles-docker:
 	docker run --rm \
 	  -it \
 	  --name devtest \


### PR DESCRIPTION
The `build` dependency makes sense when `make textfiles-docker` is run inside the `okdoc` folder. However, it will usually be run one folder higher, in the documents repo. Then, the `build` dependency will break the `make` task.